### PR TITLE
Remove home-manager self management

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -4,11 +4,6 @@ let
   nixpkgs = specialArgs.nixpkgs;
   nixpkgs-unstable = specialArgs.nixpkgs-unstable;
 in {
-  # Let Home Manager install and manage itself.
-  programs = {
-    home-manager.enable = true;
-  };
-
   # Home Manager needs a bit of information about you and the
   # paths it should manage.
   home.username = "roni";


### PR DESCRIPTION
Since home-manager is being deployed through the system level module, this is no longer necessary.