### PR TITLE
Fix issues with XMonad configuration (and similar issues elsewhere)

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -62,5 +62,10 @@ in {
 
     # ZShell.
     ".zshrc".source = substituteAll {
+      src = ./sources/zsh/zshrc;
+
+      shotgun = "${shotgun}/bin/shotgun";
+      slop = "${slop}/bin/slop";
+    };
   };
 }

--- a/home.nix
+++ b/home.nix
@@ -37,7 +37,7 @@ in {
 
     ".xmonad/xmobarrc".source = ./sources/xmonad/xmobarrc;
 
-    ".xmonad/battpercent.sh".source = nixpkgs.substituteAll {
+    ".xmonad/battpercent.sh".source = substituteAll {
       src = ./sources/xmonad/battpercent.sh;
       isExecutable = true;
 
@@ -48,7 +48,7 @@ in {
     ".config/alacritty/alacritty.yml".source = ./sources/alacritty/alacritty.yml;
 
     # Git.
-    ".gitconfig".source = nixpkgs.substituteAll {
+    ".gitconfig".source = substituteAll {
       src = ./sources/git/gitconfig;
 
       diffsofancy = "${diff-so-fancy}/bin/diff-so-fancy";
@@ -61,6 +61,6 @@ in {
     ".tmux.conf".source = ./sources/tmux/tmux.conf;
 
     # ZShell.
-    ".zshrc".source = ./sources/zsh/zshrc;
+    ".zshrc".source = substituteAll {
   };
 }

--- a/home.nix
+++ b/home.nix
@@ -21,7 +21,7 @@ in {
 
   home.file = with nixpkgs; {
     # XMonad.
-    ".xmonad/xmonad.hs".source = nixpkgs.substituteAll {
+    ".xmonad/xmonad.hs".source = substituteAll {
       src = ./sources/xmonad/xmonad.hs;
 
       alacritty = "${alacritty}/bin/alacritty";

--- a/machines/kahless/packages.nix
+++ b/machines/kahless/packages.nix
@@ -7,7 +7,6 @@
     pmutils
     shotgun
     slop
-    tmuxinator
     xclip
     xorg.xmodmap
 

--- a/machines/kahless/packages.nix
+++ b/machines/kahless/packages.nix
@@ -4,8 +4,6 @@
   environment.systemPackages = with nixpkgs; [
     # System packages.
     kbfs
-    shotgun
-    slop
     xorg.xmodmap
 
     # User packages.

--- a/machines/kahless/packages.nix
+++ b/machines/kahless/packages.nix
@@ -4,7 +4,6 @@
   environment.systemPackages = with nixpkgs; [
     # System packages.
     kbfs
-    pmutils
     shotgun
     slop
     xorg.xmodmap

--- a/machines/kahless/packages.nix
+++ b/machines/kahless/packages.nix
@@ -2,10 +2,6 @@
 
 {
   environment.systemPackages = with nixpkgs; [
-    # System packages.
-    kbfs
-
-    # User packages.
     bat
     brave
     elgato

--- a/machines/kahless/packages.nix
+++ b/machines/kahless/packages.nix
@@ -7,7 +7,6 @@
     pmutils
     shotgun
     slop
-    xclip
     xorg.xmodmap
 
     # User packages.
@@ -37,6 +36,7 @@
     unzip
     up
     vscode
+    xclip
     yadm
     yarn
     zoom-us

--- a/machines/kahless/packages.nix
+++ b/machines/kahless/packages.nix
@@ -4,7 +4,6 @@
   environment.systemPackages = with nixpkgs; [
     # System packages.
     kbfs
-    xorg.xmodmap
 
     # User packages.
     bat

--- a/machines/kahless/packages.nix
+++ b/machines/kahless/packages.nix
@@ -3,19 +3,13 @@
 {
   environment.systemPackages = with nixpkgs; [
     # System packages.
-    alacritty
     kbfs
     pmutils
-    rofi
     shotgun
     slop
     tmuxinator
     xclip
-    xlockmore
-    xorg.xbacklight
     xorg.xmodmap
-    xmonad-with-packages
-    xmobar
 
     # User packages.
     bat

--- a/machines/kahless/services/keybase.nix
+++ b/machines/kahless/services/keybase.nix
@@ -1,7 +1,11 @@
-{ ... }:
+{ nixpkgs, ... }:
 
 {
   services.keybase = {
     enable = true;
   };
+
+  environment.systemPackages = with nixpkgs; [
+    kbfs
+  ];
 }

--- a/sources/xmonad/xmonad.hs
+++ b/sources/xmonad/xmonad.hs
@@ -112,7 +112,7 @@ myKeys conf@(XConfig {XMonad.modMask = modMask}) = M.fromList $
       , ((modMask .|. shiftMask, xK_q     ), io (exitWith ExitSuccess))
 
     -- Restart xmonad
-      , ((modMask              , xK_q     ), restart "xmonad" True)
+      , ((modMask              , xK_q     ), spawn "@xmonad@ --recompile && @xmonad@ --restart")
     ] ++
 
     -- mod-[1..9], Switch to workspace N

--- a/sources/zsh/zshrc
+++ b/sources/zsh/zshrc
@@ -106,7 +106,7 @@ alias serve="python3 -m http.server"
 function faketty { script -qfc "$(printf "%q " "$@")"; }
 
 function xcap() {
-    shotgun -f png -g $(slop) $1
+    @shotgun@ -f png -g $(@slop@) $1
 }
 
 # nix-shell shortcut


### PR DESCRIPTION
This replaces the basic xmonad restart logic with a forced recompilation. See commit message a29c1c516de51a0dc806186eecdf13a50c5987f0 for details.

It also eliminates other packages from the full system package list that don't need to be there (for similar reasons as the XMonad fix).